### PR TITLE
handle tile flips and also cache all possible tile transformations

### DIFF
--- a/object.go
+++ b/object.go
@@ -145,7 +145,6 @@ func (o *Object) GetTile() (*DecodedTile, error) {
 		o.tile = &DecodedTile{
 			ID:        o.GID,
 			Tileset:   ts,
-			pos:       pixel.V(o.X, o.Y),
 			parentMap: o.parentMap,
 		}
 


### PR DESCRIPTION
**Describe the changes**

This PR add the tile flipping code and also tries to pre compute and cache every possible tile transformations (except layer for its offset, because tiles are reused across layers).

**Closing issues**

Resolves #77
