### PR TITLE
Object groups from tile objects

### DIFF
--- a/map.go
+++ b/map.go
@@ -74,11 +74,17 @@ func (m *Map) DrawAll(target pixel.Target, clearColour color.Color, mat pixel.Ma
 }
 
 // GenerateTileObjectLayer will create an object layer which contains all objects as defined by individual tiles.
-func (m *Map) GenerateTileObjectLayer() {
+func (m *Map) GenerateTileObjectLayer() error {
 	for _, ts := range m.Tilesets {
 		objGroup := ts.GenerateTileObjectLayer(m.TileLayers)
+		if err := objGroup.decode(); err != nil {
+			log.WithField("ObjectGroup", objGroup).WithError(err).Error("Map.GenerateTileObjectLayer: could not deccode object group")
+			return err
+		}
 		m.ObjectGroups = append(m.ObjectGroups, &objGroup)
 	}
+
+	return nil
 }
 
 // GetImageLayerByName returns a Map's ImageLayer by its name

--- a/map.go
+++ b/map.go
@@ -73,6 +73,14 @@ func (m *Map) DrawAll(target pixel.Target, clearColour color.Color, mat pixel.Ma
 	return nil
 }
 
+// GenerateTileObjectLayer will create an object layer which contains all objects as defined by individual tiles.
+func (m *Map) GenerateTileObjectLayer() {
+	for _, ts := range m.Tilesets {
+		objGroup := ts.GenerateTileObjectLayer(m.TileLayers)
+		m.ObjectGroups = append(m.ObjectGroups, &objGroup)
+	}
+}
+
 // GetImageLayerByName returns a Map's ImageLayer by its name
 func (m *Map) GetImageLayerByName(name string) *ImageLayer {
 	for _, l := range m.ImageLayers {

--- a/map_test.go
+++ b/map_test.go
@@ -84,6 +84,47 @@ func TestCentre(t *testing.T) {
 	}
 }
 
+func TestMap_GenerateTileObjectLayer(t *testing.T) {
+	m, err := tilepix.ReadFile("testdata/tileobjectgroups.tmx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := m.GenerateTileObjectLayer(); err != nil {
+		t.Fatal(err)
+	}
+
+	const objectLayerName = "singleWhite-objectgroup"
+
+	l := m.GetObjectLayerByName(objectLayerName)
+	if l == nil {
+		t.Fatalf("no object group by name '%s", objectLayerName)
+	}
+
+	if len(l.Objects) != 5 {
+		t.Fatalf("Expected 5 objects, got %d", len(l.Objects))
+	}
+
+	expectedPos := [...]pixel.Rect{
+		pixel.R(16, 144, 48, 176),
+		pixel.R(48, 144, 80, 176),
+		pixel.R(80, 144, 112, 176),
+		pixel.R(112, 144, 144, 176),
+		pixel.R(144, 144, 176, 176),
+	}
+
+	for i, obj := range l.Objects {
+		r, err := obj.GetRect()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expR := expectedPos[i]
+		if !r.Max.Eq(expR.Max) || !r.Min.Eq(expR.Min) {
+			t.Fatalf("Mismatching objects, expected %v, got %v", expR, r)
+		}
+	}
+}
+
 func TestMap_DrawAll(t *testing.T) {
 	m, err := tilepix.ReadFile("examples/t1.tmx")
 	if err != nil {

--- a/testdata/tileobjectgroups.tmx
+++ b/testdata/tileobjectgroups.tmx
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.2" tiledversion="1.2.4" orientation="orthogonal" renderorder="right-down" width="5" height="5" tilewidth="32" tileheight="32" infinite="0" nextlayerid="2" nextobjectid="1">
+ <tileset firstgid="1" name="singleWhite" tilewidth="32" tileheight="32" tilecount="1" columns="1">
+  <image source="singleWhite.png" width="32" height="32"/>
+  <tile id="0">
+   <objectgroup draworder="index">
+    <object id="1" x="0.0" y="0.0" width="32.0" height="32.0"/>
+   </objectgroup>
+  </tile>
+ </tileset>
+ <layer id="1" name="layer1" width="5" height="5">
+  <data encoding="csv">
+1,1,1,1,1,
+0,0,0,0,0,
+0,0,0,0,0,
+0,0,0,0,0,
+0,0,0,0,0
+</data>
+ </layer>
+</map>

--- a/tile.go
+++ b/tile.go
@@ -18,6 +18,8 @@ import (
 type Tile struct {
 	ID    ID     `xml:"id,attr"`
 	Image *Image `xml:"image"`
+	// ObjectGroup is set if objects have been added to individual sprites in Tiled.
+	ObjectGroup *ObjectGroup `xml:"objectgroup,omitempty"`
 
 	// parentMap is the map which contains this object
 	parentMap *Map
@@ -62,8 +64,7 @@ func (t *DecodedTile) Draw(ind, columns, numRows int, ts *Tileset, target pixel.
 		t.setSprite(columns, numRows, ts)
 
 		// Calculate the framing for the tile within its tileset's source image
-		gamePos := indexToGamePos(ind, t.parentMap.Width, t.parentMap.Height)
-		pos := gamePos.ScaledXY(pixel.V(float64(ts.TileWidth), float64(ts.TileHeight))).Add(pixel.V(float64(ts.TileWidth), float64(ts.TileHeight)).Scaled(0.5))
+		pos := t.Position(ind, ts)
 		transform := pixel.IM.Moved(pos)
 		if t.DiagonalFlip {
 			transform = transform.Rotated(pos, math.Pi/2)
@@ -78,6 +79,12 @@ func (t *DecodedTile) Draw(ind, columns, numRows int, ts *Tileset, target pixel.
 		t.transform = transform
 	}
 	t.sprite.Draw(target, t.transform.Moved(offset))
+}
+
+// Position returns the relative game position.
+func (t DecodedTile) Position(ind int, ts *Tileset) pixel.Vec {
+	gamePos := indexToGamePos(ind, t.parentMap.Width, t.parentMap.Height)
+	return gamePos.ScaledXY(pixel.V(float64(ts.TileWidth), float64(ts.TileHeight))).Add(pixel.V(float64(ts.TileWidth), float64(ts.TileHeight)).Scaled(0.5))
 }
 
 func (t *DecodedTile) String() string {

--- a/tileset.go
+++ b/tileset.go
@@ -83,6 +83,11 @@ func (ts Tileset) GenerateTileObjectLayer(tileLayers []*TileLayer) ObjectGroup {
 	for _, tl := range tileLayers {
 		// Loop all DecodedTiles in the TileLayer
 		for ind, t := range tl.DecodedTiles {
+			if t.Nil {
+				// Skip blank tiles.
+				continue
+			}
+
 			// Try get the Tiles' ObjectGroup.
 			og, ok := objs[t.ID]
 			if !ok {
@@ -93,11 +98,12 @@ func (ts Tileset) GenerateTileObjectLayer(tileLayers []*TileLayer) ObjectGroup {
 			// Loop all objects in the Tiles' ObjectGroup.
 			for _, obs := range og.Objects {
 				// Create a new Object based on the relative position of the Object and the DecodedTile.
-				o := obs
-				o.X += t.Position(ind, &ts).X
-				o.Y += t.Position(ind, &ts).Y
+				o := *obs
+				tilePos := t.Position(ind, &ts)
+				o.X += tilePos.X
+				o.Y += tilePos.Y
 
-				group.Objects = append(group.Objects, o)
+				group.Objects = append(group.Objects, &o)
 			}
 		}
 	}
@@ -160,7 +166,9 @@ func (ts *Tileset) setSprite() pixel.Picture {
 func (ts Tileset) TileObjects() map[ID]*ObjectGroup {
 	objs := make(map[ID]*ObjectGroup)
 	for _, t := range ts.Tiles {
-		objs[t.ID] = t.ObjectGroup
+		if t.ObjectGroup != nil {
+			objs[t.ID] = t.ObjectGroup
+		}
 	}
 
 	return objs


### PR DESCRIPTION
Adds functionality to create `ObjectGroup`s when created on tiles in Tiled using this method:
https://doc.mapeditor.org/en/stable/manual/editing-tilesets/#tile-collision-editor