### PR TITLE
add support for virtual filesystems

### DIFF
--- a/tilepix_test.go
+++ b/tilepix_test.go
@@ -106,7 +106,7 @@ func TestRead(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := tilepix.Read(tt.input, tt.dir)
+			_, err := tilepix.Read(tt.input, tt.dir, nil)
 
 			if tt.wantErr && err == nil {
 				t.Errorf("tsx.Read: expected error but not nil")


### PR DESCRIPTION
**Checklist**
Ensure all of these are completed before opening the PR:
 - [x] Run `goimports`
 - [x] Read the [contribution guide](https://github.com/bcvery1/tilepix/blob/master/CONTRIBUTING.md)
 - [x] Read the [code of conduct](https://github.com/bcvery1/tilepix/blob/master/CODE_OF_CONDUCT.md)
 - [x] Read the [coding standards](https://github.com/bcvery1/tilepix/blob/master/CODING_STANDARDS.md)
 - [x] Tests run with `-race`
 - [x] Tests written to cover any new code
 - [x] Added yourself to the [contributors file](https://github.com/bcvery1/tilepix/blob/master/CONTRIBUTORS.md)

**Describe the changes**
Brief explanation about what changed in this PR.
Adds a parameter to `Read`, set to `nil` to function like current
Breaks all users of Read, just add `nil`

**Closing issues**
Resolves #98 
