### PR TITLE
Add BackgroundColor attribute to Map struct

### DIFF
--- a/map.go
+++ b/map.go
@@ -34,6 +34,7 @@ type Map struct {
 	ObjectGroups []*ObjectGroup `xml:"objectgroup"`
 	Infinite     bool           `xml:"infinite,attr"`
 	ImageLayers  []*ImageLayer  `xml:"imagelayer"`
+        BackgroundColor string      `xml:"backgroundcolor,attr"`
 
 	canvas *pixelgl.Canvas
 	// dir is the directory the tmx file is located in.  This is used to access images for tilesets via a relative path.


### PR DESCRIPTION
This patch extends the Map struct of tilepix with the background color set in Tiled.

I am using this attribute in a 2D game of mine (https://github.com/objarni/rescue-on-fractal-bun/) and my GitHub Action CI pipeline is failing because I've added this attribute to a local clone of tilepix. Would be grateful if you could merge this so my build can pass again :)

<3

**Checklist**
Ensure all of these are completed before opening the PR:
 - [ ] Run `goimports`
 - [ ] Read the [contribution guide](https://github.com/bcvery1/tilepix/blob/master/CONTRIBUTING.md)
 - [ ] Read the [code of conduct](https://github.com/bcvery1/tilepix/blob/master/CODE_OF_CONDUCT.md)
 - [ ] Read the [coding standards](https://github.com/bcvery1/tilepix/blob/master/CODING_STANDARDS.md)
 - [ ] Tests run with `-race`
 - [ ] Tests written to cover any new code
 - [ ] Added yourself to the [contributors file](https://github.com/bcvery1/tilepix/blob/master/CONTRIBUTORS.md)

**Describe the changes**
Brief explanation about what changed in this PR.

**Closing issues**
Resolves #
